### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,8 @@ jobs:
   audit:
     name: Cargo Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
Potential fix for [https://github.com/obstreperous-ai/rust-slint-password-saver/security/code-scanning/4](https://github.com/obstreperous-ai/rust-slint-password-saver/security/code-scanning/4)

In general, to fix this issue you should explicitly declare a `permissions` block for the workflow or for each job, granting only the minimal scopes required. For this workflow, the job only checks out code and runs `cargo audit`, so it only needs read access to repository contents, and possibly default read access to packages if ever used. No write permissions are required.

The best fix here is to add a `permissions` block either at the root (so it applies to all jobs) or directly under the `audit` job. To keep the change tightly scoped and aligned with the CodeQL message (which highlights the job), we can add it under `jobs.audit`. The block should specify `contents: read`, which is sufficient for `actions/checkout@v4` to read the repository. No other permissions appear necessary based on the current steps.

Concretely, in `.github/workflows/security.yml`, under `jobs:`, inside the `audit:` job definition (around line 23), insert:

```yaml
    permissions:
      contents: read
```

with the correct indentation (two extra spaces relative to `audit:` and aligned with `name:` and `runs-on:`). No additional imports or methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
