### PR TITLE
Potential fix for code scanning alert no. 154: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: Build Release
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     env:
       # Authenticode signing credentials — set these secrets in Settings → Secrets and variables → Actions
       # to enable automatic signing of the Windows release binary.  When any of these are absent the


### PR DESCRIPTION
Potential fix for [https://github.com/obstreperous-ai/rust-slint-password-saver/security/code-scanning/154](https://github.com/obstreperous-ai/rust-slint-password-saver/security/code-scanning/154)

In general, the fix is to explicitly define a `permissions:` block so the `GITHUB_TOKEN` used in the `build` job does not inherit potentially broad repository defaults. We should grant the least privilege necessary. This job only needs to read the repository contents for `actions/checkout` and does not push or modify anything, and `actions/upload-artifact`/`download-artifact` do not use `GITHUB_TOKEN` but a separate internal token. Therefore, we can safely set `permissions: contents: read` for the `build` job.

The best, minimal fix without changing behavior is to add a `permissions:` section under `jobs.build`, alongside `runs-on` and `env`, mirroring the existing structure used by the `release` job. Specifically, in `.github/workflows/release.yml`, between lines 14 and 15 (between `runs-on: ${{ matrix.os }}` and `env:` for the `build` job), insert:

```yaml
    permissions:
      contents: read
```

No additional imports or external dependencies are required; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
